### PR TITLE
Handle failing file_get_contents calls

### DIFF
--- a/submit.php
+++ b/submit.php
@@ -84,6 +84,13 @@ $options = [
 ];
 $context = stream_context_create($options);
 $result = file_get_contents('https://idcheck.expressmarketinginc.com/intake/', false, $context);
+if ($result === false) {
+    $err = error_get_last();
+    $msg = $err['message'] ?? 'Unknown error';
+    file_put_contents("submit_error.log", "[HTTP ERROR] {$msg}\n", FILE_APPEND);
+    header("Location: index.php?error=2");
+    exit;
+}
 $response = json_decode($result, true);
 
 // Handle API response

--- a/webhook.php
+++ b/webhook.php
@@ -3,6 +3,14 @@ require 'config.php';
 require 'mail.php';
 
 $input = file_get_contents('php://input');
+if ($input === false) {
+    $err = error_get_last();
+    $msg = $err['message'] ?? 'Unable to read request body';
+    file_put_contents(LOG_PATH, "[ERROR] Input read failed: {$msg}\n", FILE_APPEND);
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid request']);
+    exit;
+}
 $data = json_decode($input, true);
 
 // Extract values


### PR DESCRIPTION
## Summary
- detect `file_get_contents` failures
- log the error reason
- show a friendly message when webhook or submit request fails

## Testing
- `phpunit tests/SubmitTest.php`

------
https://chatgpt.com/codex/tasks/task_e_6840a40589788328a07291834437d582