### PR TITLE
Add error handling for API failures

### DIFF
--- a/submit.php
+++ b/submit.php
@@ -84,6 +84,11 @@ $options = [
 ];
 $context = stream_context_create($options);
 $result = file_get_contents('https://idcheck.expressmarketinginc.com/intake/', false, $context);
+if ($result === false) {
+    file_put_contents("submit_error.log", "[FETCH ERROR] " . json_encode(error_get_last()) . "\n", FILE_APPEND);
+    header("Location: index.php?error=2");
+    exit;
+}
 $response = json_decode($result, true);
 
 // Handle API response


### PR DESCRIPTION
## Summary
- handle HTTP request failures before decoding API response

## Testing
- `phpunit tests` *(fails: Failed opening required '/workspace/verify/vendor/composer/autoload_real.php')*

------
https://chatgpt.com/codex/tasks/task_e_68409a10b650832899a20e6fc6fe824b