### PR TITLE
Fix admin login check

### DIFF
--- a/admin/auth.php
+++ b/admin/auth.php
@@ -1,5 +1,11 @@
 <?php
 require '../config.php';
+
+if (!isset($_POST['username'], $_POST['password'])) {
+    header('Location: login.php');
+    exit;
+}
+
 if ($_POST['username'] === ADMIN_USER && $_POST['password'] === ADMIN_PASS) {
     $_SESSION['admin'] = true;
     header("Location: dashboard.php");


### PR DESCRIPTION
## Summary
- check that username and password are provided before validating credentials

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68409a0f05a8832880f38e333c650d24