### PR TITLE
Add failure flow

### DIFF
--- a/failure.php
+++ b/failure.php
@@ -1,0 +1,20 @@
+<?php require 'config.php'; ?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Verification Failed - Find The Firm</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+<div class="container py-5 text-center">
+    <img src="assets/logo.png" alt="Find The Firm" class="logo mb-4">
+    <h2 class="mb-3">We could not verify your identity.</h2>
+    <p class="lead">Your ID check was unsuccessful. Please try again or contact our support team if you believe this is an error.</p>
+    <p class="lead"><a href="mailto:support@findthefirm.com">support@findthefirm.com</a></p>
+    <a href="index.php" class="btn btn-outline-primary mt-4">Start Over</a>
+</div>
+</body>
+</html>

--- a/mail.php
+++ b/mail.php
@@ -24,4 +24,29 @@ function sendAdminEmail($subject, $bodyHtml) {
         file_put_contents(LOG_PATH, "[EMAIL ERROR] " . $mail->ErrorInfo . "\n", FILE_APPEND);
     }
 }
+
+function sendFailureEmail(string $toEmail, string $toName, string $failureLink): void
+{
+    $mail = new PHPMailer(true);
+    try {
+        $mail->isSMTP();
+        $mail->Host = SMTP_HOST;
+        $mail->SMTPAuth = true;
+        $mail->Username = SMTP_USER;
+        $mail->Password = SMTP_PASS;
+        $mail->SMTPSecure = PHPMailer::ENCRYPTION_SMTPS;
+        $mail->Port = SMTP_PORT;
+        $mail->setFrom(SENDER_EMAIL, 'Find The Firm');
+        $mail->addAddress($toEmail, $toName);
+        $mail->isHTML(true);
+        $mail->Subject = 'ID Verification Failed';
+        $mail->Body = "<p>Hi {$toName},</p>"
+            . '<p>Unfortunately, we were unable to verify your identity.</p>'
+            . "<p>Please visit <a href='{$failureLink}'>this page</a> for next steps.</p>";
+        $mail->AltBody = "We were unable to verify your identity. Visit {$failureLink} for next steps.";
+        $mail->send();
+    } catch (Exception $e) {
+        file_put_contents(LOG_PATH, "[EMAIL ERROR] " . $mail->ErrorInfo . "\n", FILE_APPEND);
+    }
+}
 ?>


### PR DESCRIPTION
## Summary
- add new `failure.php` page to inform users of a failed ID check
- create `sendFailureEmail()` helper for user notifications
- update `webhook.php` to email the user when a record fails
- log when the failure email is sent

## Testing
- `vendor/bin/phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_6840c063064c8328b89a0854ba4130cb