### PR TITLE
Fix webhook DB connection usage

### DIFF
--- a/webhook.php
+++ b/webhook.php
@@ -2,6 +2,9 @@
 require 'config.php';
 require 'mail.php';
 
+$db = new PDO("sqlite:" . DB_PATH);
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
 $input = file_get_contents('php://input');
 $data = json_decode($input, true);
 
@@ -15,9 +18,9 @@ $timestamp = date('c');
 
 // Log to DB
 try {
-    $db = new PDO("sqlite:" . DB_PATH);
-    $stmt = $db->prepare("INSERT INTO webhook_logs (event_id, lead_status, message, info, details, received_at)
-                          VALUES (?, ?, ?, ?, ?, ?)");
+    $stmt = $db->prepare(
+        "INSERT INTO webhook_logs (event_id, lead_status, message, info, details, received_at) VALUES (?, ?, ?, ?, ?, ?)"
+    );
     $stmt->execute([$eventId, $status, $message, $info, $details, $timestamp]);
 } catch (Exception $e) {
     file_put_contents(LOG_PATH, "[ERROR] DB log failed: " . $e->getMessage() . "\n", FILE_APPEND);


### PR DESCRIPTION
## Summary
- create DB connection once in `webhook.php`
- set error mode to exceptions
- reuse the same PDO instance for webhook logging and status update

## Testing
- `./vendor/bin/phpunit tests/SubmitTest.php`

------
https://chatgpt.com/codex/tasks/task_e_6840c061e4348328be9f8bbaf929fd15