### PR TITLE
Handle invalid JSON in webhook

### DIFF
--- a/tests/WebhookTest.php
+++ b/tests/WebhookTest.php
@@ -1,0 +1,19 @@
+<?php
+// prevent script execution when included
+if (!defined('TESTING')) {
+    define('TESTING', true);
+}
+require_once __DIR__ . '/../webhook.php';
+
+use PHPUnit\Framework\TestCase;
+
+class WebhookTest extends TestCase
+{
+    public function testInvalidJsonReturns400()
+    {
+        [$status, $response] = handleWebhook('{bad json');
+        $this->assertEquals(400, $status);
+        $this->assertIsArray($response);
+        $this->assertArrayHasKey('error', $response);
+    }
+}

--- a/webhook.php
+++ b/webhook.php
@@ -2,45 +2,61 @@
 require 'config.php';
 require 'mail.php';
 
-$input = file_get_contents('php://input');
-$data = json_decode($input, true);
+function handleWebhook(string $input): array
+{
+    $data = json_decode($input, true);
 
-// Extract values
-$status  = $data['status'] ?? 'unknown';
-$info    = json_encode($data['info'] ?? []);
-$details = json_encode($data['details'] ?? []);
-$message = $data['message'] ?? '';
-$eventId = $data['id'] ?? '';
-$timestamp = date('c');
+    if (json_last_error() !== JSON_ERROR_NONE || $data === null) {
+        file_put_contents(LOG_PATH, "[ERROR] Invalid JSON payload\n", FILE_APPEND);
+        return [400, ['error' => 'Invalid JSON']];
+    }
 
-// Log to DB
-try {
-    $db = new PDO("sqlite:" . DB_PATH);
-    $stmt = $db->prepare("INSERT INTO webhook_logs (event_id, lead_status, message, info, details, received_at)
+    // Extract values
+    $status  = $data['status'] ?? 'unknown';
+    $info    = json_encode($data['info'] ?? []);
+    $details = json_encode($data['details'] ?? []);
+    $message = $data['message'] ?? '';
+    $eventId = $data['id'] ?? '';
+    $timestamp = date('c');
+
+    // Log to DB
+    try {
+        $db = new PDO("sqlite:" . DB_PATH);
+        $stmt = $db->prepare("INSERT INTO webhook_logs (event_id, lead_status, message, info, details, received_at)
                           VALUES (?, ?, ?, ?, ?, ?)");
-    $stmt->execute([$eventId, $status, $message, $info, $details, $timestamp]);
-} catch (Exception $e) {
-    file_put_contents(LOG_PATH, "[ERROR] DB log failed: " . $e->getMessage() . "\n", FILE_APPEND);
+        $stmt->execute([$eventId, $status, $message, $info, $details, $timestamp]);
+    } catch (Exception $e) {
+        file_put_contents(LOG_PATH, "[ERROR] DB log failed: " . $e->getMessage() . "\n", FILE_APPEND);
+    }
+
+    // Update lead status
+    try {
+        $stmt = $db->prepare("UPDATE verifications SET status = ?, message = ? WHERE plaid_id = ?");
+        $stmt->execute([$status, $message, $eventId]);
+    } catch (Exception $e) {
+        file_put_contents(LOG_PATH, "[ERROR] Verification update failed: " . $e->getMessage() . "\n", FILE_APPEND);
+    }
+
+    // Email alert if failed
+    if (strtolower($status) === 'failed') {
+        $subject = "⚠️ Verification Failed - Event {$eventId}";
+        $body = "Verification failed at: {$timestamp}<br><br>
+                 <strong>Message:</strong> {$message}<br>
+                 <strong>Info:</strong><pre>{$info}</pre><br>
+                 <strong>Details:</strong><pre>{$details}</pre><br>";
+        sendAdminEmail($subject, $body);
+    }
+
+    return [200, ['received' => true]];
 }
 
-// Update lead status
-try {
-    $stmt = $db->prepare("UPDATE verifications SET status = ?, message = ? WHERE plaid_id = ?");
-    $stmt->execute([$status, $message, $eventId]);
-} catch (Exception $e) {
-    file_put_contents(LOG_PATH, "[ERROR] Verification update failed: " . $e->getMessage() . "\n", FILE_APPEND);
+if (defined('TESTING') && TESTING) {
+    return;
 }
 
-// Email alert if failed
-if (strtolower($status) === 'failed') {
-    $subject = "⚠️ Verification Failed - Event {$eventId}";
-    $body = "Verification failed at: {$timestamp}<br><br>
-             <strong>Message:</strong> {$message}<br>
-             <strong>Info:</strong><pre>{$info}</pre><br>
-             <strong>Details:</strong><pre>{$details}</pre><br>";
-    sendAdminEmail($subject, $body);
-}
+$input = file_get_contents('php://input');
+[$statusCode, $response] = handleWebhook($input);
 
-http_response_code(200);
-echo json_encode(['received' => true]);
+http_response_code($statusCode);
+echo json_encode($response);
 ?>


### PR DESCRIPTION
## Summary
- validate JSON payloads in `webhook.php`
- return HTTP 400 when JSON decoding fails and log the problem
- add PHPUnit test for invalid webhook JSON

## Testing
- `phpunit tests --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6840c06178008328837a1042ee2a150f