### PR TITLE
Fix search filter parentheses in export

### DIFF
--- a/admin/export.php
+++ b/admin/export.php
@@ -13,7 +13,7 @@ $where = [];
 $params = [];
 
 if (!empty($_GET['search'])) {
-    $where[] = "(first_name || ' ' || last_name LIKE :search OR email LIKE :search)";
+    $where[] = "((first_name || ' ' || last_name) LIKE :search OR email LIKE :search)";
     $params[':search'] = "%" . $_GET['search'] . "%";
 }
 if (!empty($_GET['status'])) {


### PR DESCRIPTION
## Summary
- fix search filter parentheses in `admin/export.php`

## Testing
- `composer test` *(fails: command not found)*
- `phpunit tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c6009f7c8328b0b6bdab25ee4a17