### PR TITLE
Simplify webhook handler

### DIFF
--- a/webhook.php
+++ b/webhook.php
@@ -2,126 +2,90 @@
 require 'config.php';
 require 'mail.php';
 
-codex/handle-invalid-json-input-in-webhook.php
 function handleWebhook(string $input): array
 {
+    // Validate JSON payload
     $data = json_decode($input, true);
-
     if (json_last_error() !== JSON_ERROR_NONE || $data === null) {
         file_put_contents(LOG_PATH, "[ERROR] Invalid JSON payload\n", FILE_APPEND);
         return [400, ['error' => 'Invalid JSON']];
     }
 
-    // Extract values
-    $status  = $data['status'] ?? 'unknown';
-    $info    = json_encode($data['info'] ?? []);
-    $details = json_encode($data['details'] ?? []);
-    $message = $data['message'] ?? '';
-    $eventId = $data['id'] ?? '';
-    $timestamp = date('c');
-
-    // Log to DB
+    // Connect to database
     try {
-        $db = new PDO("sqlite:" . DB_PATH);
-        $stmt = $db->prepare("INSERT INTO webhook_logs (event_id, lead_status, message, info, details, received_at)
-                          VALUES (?, ?, ?, ?, ?, ?)");
-        $stmt->execute([$eventId, $status, $message, $info, $details, $timestamp]);
+        $db = new PDO('sqlite:' . DB_PATH);
+        $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    } catch (Exception $e) {
+        file_put_contents(LOG_PATH, "[ERROR] DB connection failed: " . $e->getMessage() . "\n", FILE_APPEND);
+        return [500, ['error' => 'Database error']];
+    }
+
+    // Extract values
+    $status     = $data['status'] ?? 'unknown';
+    $info       = json_encode($data['info'] ?? []);
+    $details    = json_encode($data['details'] ?? []);
+    $message    = $data['message'] ?? '';
+    $eventId    = $data['id'] ?? '';
+    $eventTime  = isset($data['unixtime']) ? date('c', $data['unixtime']) : null;
+    $receivedAt = date('c');
+
+    // Log webhook payload
+    try {
+        $stmt = $db->prepare(
+            'INSERT INTO webhook_logs (event_id, lead_status, message, info, details, event_time, received_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?)'
+        );
+        $stmt->execute([$eventId, $status, $message, $info, $details, $eventTime, $receivedAt]);
     } catch (Exception $e) {
         file_put_contents(LOG_PATH, "[ERROR] DB log failed: " . $e->getMessage() . "\n", FILE_APPEND);
     }
 
-$db = new PDO("sqlite:" . DB_PATH);
-$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-
-$input = file_get_contents('php://input');
-$data = json_decode($input, true);
-
-// Extract values
-$status  = $data['status'] ?? 'unknown';
-$info    = json_encode($data['info'] ?? []);
-$details = json_encode($data['details'] ?? []);
-$message = $data['message'] ?? '';
-$eventId = $data['id'] ?? '';
-$eventTime = isset($data['unixtime']) ? date('c', $data['unixtime']) : null;
-$receivedAt = date('c');
-
-// Log to DB
-try {
- codex/refactor-pdo-initialization-and-error-handling
-    $stmt = $db->prepare(
-        "INSERT INTO webhook_logs (event_id, lead_status, message, info, details, received_at) VALUES (?, ?, ?, ?, ?, ?)"
-    );
-    $stmt->execute([$eventId, $status, $message, $info, $details, $timestamp]);
-
-    $db = new PDO("sqlite:" . DB_PATH);
-    $stmt = $db->prepare("INSERT INTO webhook_logs (event_id, lead_status, message, info, details, event_time, received_at)
-                          VALUES (?, ?, ?, ?, ?, ?, ?)");
-    $stmt->execute([$eventId, $status, $message, $info, $details, $eventTime, $receivedAt]);
- main
-} catch (Exception $e) {
-    file_put_contents(LOG_PATH, "[ERROR] DB log failed: " . $e->getMessage() . "\n", FILE_APPEND);
-}
- main
-
-    // Update lead status
+    // Update verification status
     try {
-        $stmt = $db->prepare("UPDATE verifications SET status = ?, message = ? WHERE plaid_id = ?");
+        $stmt = $db->prepare('UPDATE verifications SET status = ?, message = ? WHERE plaid_id = ?');
         $stmt->execute([$status, $message, $eventId]);
     } catch (Exception $e) {
         file_put_contents(LOG_PATH, "[ERROR] Verification update failed: " . $e->getMessage() . "\n", FILE_APPEND);
     }
 
-    // Email alert if failed
+    // Send notifications for failed status
     if (strtolower($status) === 'failed') {
+        $timeForEmail = $eventTime ?? $receivedAt;
         $subject = "⚠️ Verification Failed - Event {$eventId}";
-        $body = "Verification failed at: {$timestamp}<br><br>
-                 <strong>Message:</strong> {$message}<br>
-                 <strong>Info:</strong><pre>{$info}</pre><br>
-                 <strong>Details:</strong><pre>{$details}</pre><br>";
+        $body = "Verification failed at: {$timeForEmail}<br><br>"
+              . "<strong>Message:</strong> {$message}<br>"
+              . "<strong>Info:</strong><pre>{$info}</pre><br>"
+              . "<strong>Details:</strong><pre>{$details}</pre><br>";
         sendAdminEmail($subject, $body);
+
+        try {
+            $stmt = $db->prepare('SELECT first_name, email FROM verifications WHERE plaid_id = ? LIMIT 1');
+            $stmt->execute([$eventId]);
+            if ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+                $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https://' : 'http://';
+                $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+                $failureLink = rtrim($scheme . $host, '/') . '/failure.php';
+                sendFailureEmail($row['email'], $row['first_name'], $failureLink);
+
+                // record notification in logs
+                $infoJson = json_encode(['email' => $row['email']]);
+                $logStmt = $db->prepare(
+                    'INSERT INTO webhook_logs (event_id, lead_status, message, info, details, received_at)
+                     VALUES (?, ?, ?, ?, ?, ?)'
+                );
+                $logStmt->execute([$eventId, 'notification_sent', 'Failure email sent', $infoJson, '{}', date('c')]);
+            }
+        } catch (Exception $e) {
+            file_put_contents(LOG_PATH, "[ERROR] Failure notice error: " . $e->getMessage() . "\n", FILE_APPEND);
+        }
     }
 
     return [200, ['received' => true]];
 }
 
- codex/handle-invalid-json-input-in-webhook.php
-if (defined('TESTING') && TESTING) {
-    return;
-
-// Email alert if failed
-if (strtolower($status) === 'failed') {
-    $subject = "⚠️ Verification Failed - Event {$eventId}";
-    $timeForEmail = $eventTime ?? $receivedAt;
-    $body = "Verification failed at: {$timeForEmail}<br><br>
-             <strong>Message:</strong> {$message}<br>
-             <strong>Info:</strong><pre>{$info}</pre><br>
-             <strong>Details:</strong><pre>{$details}</pre><br>";
-    sendAdminEmail($subject, $body);
-
-    // Send failure notice to user
-    try {
-        $stmt = $db->prepare("SELECT first_name, email FROM verifications WHERE plaid_id = ? LIMIT 1");
-        $stmt->execute([$eventId]);
-        if ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-            $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https://' : 'http://';
-            $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
-            $failureLink = rtrim($scheme . $host, '/') . '/failure.php';
-            sendFailureEmail($row['email'], $row['first_name'], $failureLink);
-
-            // record in logs table
-            $infoJson = json_encode(['email' => $row['email']]);
-            $stmtLog = $db->prepare("INSERT INTO webhook_logs (event_id, lead_status, message, info, details, received_at) VALUES (?, ?, ?, ?, ?, ?)");
-            $stmtLog->execute([$eventId, 'notification_sent', 'Failure email sent', $infoJson, '{}', date('c')]);
-        }
-    } catch (Exception $e) {
-        file_put_contents(LOG_PATH, "[ERROR] Failure notice error: " . $e->getMessage() . "\n", FILE_APPEND);
-    }
- main
+if (!defined('TESTING') || !TESTING) {
+    $input = file_get_contents('php://input');
+    [$status, $response] = handleWebhook($input);
+    http_response_code($status);
+    echo json_encode($response);
 }
-
-$input = file_get_contents('php://input');
-[$statusCode, $response] = handleWebhook($input);
-
-http_response_code($statusCode);
-echo json_encode($response);
-?>


### PR DESCRIPTION
## Summary
- clean up stray markers in `webhook.php`
- consolidate webhook logic into a single `handleWebhook()`
- run handler only when not in testing mode

## Testing
- `php -l webhook.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6840c5feeff88328bce30a10d470057c