### PR TITLE
Improve client-side validation feedback

### DIFF
--- a/index.php
+++ b/index.php
@@ -27,6 +27,7 @@
         <?php endif; ?>
 
         <form method="POST" action="submit.php" class="card p-4 shadow-lg border-0 rounded-4 bg-white">
+            <div id="clientError" class="alert alert-danger d-none"></div>
             <div class="row g-3">
                 <div class="col-md-6">
                     <label for="first_name" class="form-label">First Name</label>
@@ -86,6 +87,7 @@ document.addEventListener("DOMContentLoaded", function () {
     const phone = document.getElementById("phone");
     const state = document.getElementById("state");
     const zip = document.getElementById("zip");
+    const clientError = document.getElementById("clientError");
 
     function showError(input, message) {
         let error = input.parentElement.querySelector(".text-danger");
@@ -166,6 +168,11 @@ document.addEventListener("DOMContentLoaded", function () {
 
         if (!isValid) {
             e.preventDefault();
+            clientError.textContent = "Please fix the highlighted fields.";
+            clientError.classList.remove("d-none");
+            console.log("Validation failed");
+        } else {
+            clientError.classList.add("d-none");
         }
     });
 });


### PR DESCRIPTION
## Summary
- show a generic client-side error block
- highlight the error block when validation fails and log to console
- keep the block hidden when inputs are valid

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6840cb504dd483288e0e9cd6e2a18640