### PR TITLE
Add CSRF token checks

### DIFF
--- a/config.php
+++ b/config.php
@@ -15,4 +15,7 @@ define('DB_PATH', getenv('DB_PATH') ?: __DIR__ . '/db.sqlite');
 define('LOG_PATH', getenv('LOG_PATH') ?: __DIR__ . '/logs/webhook.log');
 
 session_start();
+if (empty($_SESSION['token'])) {
+    $_SESSION['token'] = bin2hex(random_bytes(32));
+}
 ?>

--- a/index.php
+++ b/index.php
@@ -27,6 +27,7 @@
         <?php endif; ?>
 
         <form method="POST" action="submit.php" class="card p-4 shadow-lg border-0 rounded-4 bg-white">
+            <input type="hidden" name="token" value="<?php echo htmlspecialchars($_SESSION['token'] ?? ''); ?>">
             <div class="row g-3">
                 <div class="col-md-6">
                     <label for="first_name" class="form-label">First Name</label>

--- a/submit.php
+++ b/submit.php
@@ -49,6 +49,11 @@ if (defined('TESTING') && TESTING) {
     return;
 }
 
+if (empty($_POST['token']) || empty($_SESSION['token']) || !hash_equals($_SESSION['token'], $_POST['token'])) {
+    http_response_code(403);
+    exit('Invalid token');
+}
+
 $data = array_map('trim', $_POST);
 if (!validate($data)) {
     header("Location: index.php?error=1");


### PR DESCRIPTION
## Summary
- generate a session token in config
- embed the token in the form
- verify token in submit.php

## Testing
- `php vendor/bin/phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_6840cb782d588328836110d70e25d24f