### PR TITLE
Fix index form markup

### DIFF
--- a/index.php
+++ b/index.php
@@ -24,17 +24,13 @@
             <div class="alert alert-danger">Please fill out all fields and accept the terms.</div>
         <?php elseif (isset($_GET['error']) && $_GET['error'] == 2): ?>
             <div class="alert alert-warning">Submission error. Please try again later.</div>
- codex/implement-token-based-csrf-protection
         <?php endif; ?>
 
         <form method="POST" action="submit.php" class="card p-4 shadow-lg border-0 rounded-4 bg-white">
             <input type="hidden" name="token" value="<?php echo htmlspecialchars($_SESSION['token'] ?? ''); ?>">
 
-        <?php endif; ?>
 
-        <form method="POST" action="submit.php" class="card p-4 shadow-lg border-0 rounded-4 bg-white">
             <div id="clientError" class="alert alert-danger d-none"></div>
- main
             <div class="row g-3">
                 <div class="col-md-6">
                     <label for="first_name" class="form-label">First Name</label>


### PR DESCRIPTION
## Summary
- clean up duplicate form tag and stray text
- keep CSRF token input intact

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840ce6836a08328bae89e7147eb73c9