### PR TITLE
Fix link path to terms

### DIFF
--- a/index.php
+++ b/index.php
@@ -76,7 +76,7 @@
                     <div class="form-check">
                         <input class="form-check-input" type="checkbox" name="terms" value="1" id="termsCheck" required>
                         <label class="form-check-label" for="termsCheck">
-                            I agree to the <a href="/verify/terms-and-privacy.html" target="_blank">terms and privacy policy</a>.
+                            I agree to the <a href="terms-and-privacy.html" target="_blank">terms and privacy policy</a>.
                         </label>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- update the terms and privacy policy link path in `index.php`

## Testing
- `phpunit tests` *(fails: command not found)*
- `vendor/bin/phpunit tests` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6840ce80c2b88328b8df4750ecf4c5b4